### PR TITLE
feat: upgrade css-loader version

### DIFF
--- a/packages/builder-pack/CHANGELOG.md
+++ b/packages/builder-pack/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.6.2
+
+- feat: upgrade css-loader version to 6.7.1

--- a/packages/builder-pack/package.json
+++ b/packages/builder-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder/pack",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "author": "ICE",
   "description": "basic dependencies",
@@ -81,7 +81,7 @@
     "cliui": "7.0.4",
     "color": "3.1.3",
     "copy-webpack-plugin": "9.0.1",
-    "css-loader": "5.2.7",
+    "css-loader": "6.7.1",
     "css-minimizer-webpack-plugin": "3.0.2",
     "debug": "4.1.1",
     "ejs": "3.1.6",

--- a/packages/builder-pack/yarn.lock
+++ b/packages/builder-pack/yarn.lock
@@ -3591,20 +3591,18 @@ css-has-pseudo@^0.10.0:
     postcss "^7.0.6"
     postcss-selector-parser "^5.0.0-rc.4"
 
-css-loader@5.2.7:
-  version "5.2.7"
-  resolved "https://registry.npmmirror.com/css-loader/download/css-loader-5.2.7.tgz?cache=0&sync_timestamp=1633783396793&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fcss-loader%2Fdownload%2Fcss-loader-5.2.7.tgz#9b9f111edf6fb2be5dc62525644cbc9c232064ae"
-  integrity sha1-m58RHt9vsr5dxiUlZEy8nCMgZK4=
+css-loader@6.7.1:
+  version "6.7.1"
+  resolved "https://registry.npmmirror.com/css-loader/-/css-loader-6.7.1.tgz#e98106f154f6e1baf3fc3bc455cb9981c1d5fd2e"
+  integrity sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==
   dependencies:
     icss-utils "^5.1.0"
-    loader-utils "^2.0.0"
-    postcss "^8.2.15"
+    postcss "^8.4.7"
     postcss-modules-extract-imports "^3.0.0"
     postcss-modules-local-by-default "^4.0.0"
     postcss-modules-scope "^3.0.0"
     postcss-modules-values "^4.0.0"
-    postcss-value-parser "^4.1.0"
-    schema-utils "^3.0.0"
+    postcss-value-parser "^4.2.0"
     semver "^7.3.5"
 
 css-minimizer-webpack-plugin@3.0.2:
@@ -6278,6 +6276,11 @@ nanoid@^3.1.30:
   resolved "https://registry.npmmirror.com/nanoid/download/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha1-Y/k8xUjSoRPcXfvGO/oJ4rm2Q2I=
 
+nanoid@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.nlark.com/nanomatch/download/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -7356,7 +7359,7 @@ postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.32, postcss@^7.0.
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.0, postcss@^8.2.15, postcss@^8.3.5:
+postcss@^8.1.0, postcss@^8.3.5:
   version "8.3.10"
   resolved "https://registry.npmmirror.com/postcss/download/postcss-8.3.10.tgz?cache=0&sync_timestamp=1634754117274&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fpostcss%2Fdownload%2Fpostcss-8.3.10.tgz#4d614e108ccc69c65c2f6dc6cec23dd5c85b73af"
   integrity sha1-TWFOEIzMacZcL23GzsI91chbc68=
@@ -7364,6 +7367,15 @@ postcss@^8.1.0, postcss@^8.2.15, postcss@^8.3.5:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.4.7:
+  version "8.4.12"
+  resolved "https://registry.npmmirror.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
+  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
+  dependencies:
+    nanoid "^3.3.1"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -8160,6 +8172,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.nlark.com/source-map-js/download/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha1-C7XeYxtBz72mz7qL0FqA79/SOF4=
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
### 背景

在 Client 端和 Server 端（SSR）中使用 css modules 时，生成的 classname 中的 hash 值部分不一致

相关 issue:
- https://github.com/webpack-contrib/css-loader/issues/1384
- https://github.com/gatsbyjs/gatsby/pull/33979/files

需要把 css-loader 的版本升级到 6.x，配合 MiniCssExtractPlugin 2.4.x 版本，此问题解决